### PR TITLE
fix: Fixes issue to launch file chooser every time

### DIFF
--- a/app/src/main/java/to/dev/dev_android/view/main/view/MainActivity.kt
+++ b/app/src/main/java/to/dev/dev_android/view/main/view/MainActivity.kt
@@ -77,15 +77,19 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), CustomWebChromeClient.
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (resultCode == Activity.RESULT_OK) {
-            if (requestCode == PIC_CHOOSER_REQUEST) {
-                if (data != null) {
-                    mFilePathCallback?.onReceiveValue(arrayOf(data.data))
-                    mFilePathCallback = null
-                }
-            }
+        if (requestCode != PIC_CHOOSER_REQUEST) {
+            return super.onActivityResult(requestCode, resultCode, data)
         }
-        super.onActivityResult(requestCode, resultCode, data)
+
+        if (resultCode == Activity.RESULT_OK) {
+            if (data != null) {
+                mFilePathCallback?.onReceiveValue(arrayOf(data.data))
+                mFilePathCallback = null
+            }
+        } else if (resultCode == Activity.RESULT_CANCELED) {
+            mFilePathCallback?.onReceiveValue(null)
+            mFilePathCallback = null
+        }
     }
 
     companion object {


### PR DESCRIPTION
- Handles the result code & completes file chooser callback with null
  return value, when the user cancels the action by clicking
  back or elsewhere

<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

This PR handle the scenario where the user cancels the file choosing operation.

## Related Tickets & Documents

[Choose File option does not work #18](https://github.com/thepracticaldev/DEV-Android/issues/18)

## Screenshots/Recordings (if there are UI changes)

![Recordings](https://github.com/subbramanil/DEV-Android/blob/docs/docs/Opening%20File%20Chooser.m4v?raw=true)

## What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/PrEUkNFD9pN2o/giphy.gif)

## Note

Tested on OnePlus2 running OxygenOS 3.6.1 Android Version: Marshmallow 6.0.1