### PR TITLE
Update Android Gradle plugin to 3.5.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.4.2")
+        classpath("com.android.tools.build:gradle:3.5.0")
         // Due an issue the full qualified name is required here. See https://github.com/gradle/kotlin-dsl/issues/1291
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${to.dev.dev_android.build.BuildConfig.kotlinVersion}")
 


### PR DESCRIPTION
[Android Studio 3.5 is now available in the stable channel](https://android-developers.googleblog.com/2019/08/android-studio-35-project-marble-goes.html).
This updates the Android Gradle plugin to `3.5.0`.