### PR TITLE
Bug/save webview state retain history

### DIFF
--- a/app/src/main/java/to/dev/dev_android/view/main/view/MainActivity.kt
+++ b/app/src/main/java/to/dev/dev_android/view/main/view/MainActivity.kt
@@ -23,7 +23,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), CustomWebChromeClient.
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setWebViewSettings()
-        savedInstanceState?.let { restoreState(it) }?: navigateToHome()
+        savedInstanceState?.let { restoreState(it) } ?: navigateToHome()
         handleIntent(intent)
     }
 
@@ -52,7 +52,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), CustomWebChromeClient.
         binding.webView.webChromeClient = CustomWebChromeClient(BuildConfig.baseUrl, binding, this)
     }
 
-    private fun restoreState(savedInstanceState: Bundle){
+    private fun restoreState(savedInstanceState: Bundle) {
         binding.webView.restoreState(savedInstanceState)
     }
 

--- a/app/src/main/java/to/dev/dev_android/view/main/view/MainActivity.kt
+++ b/app/src/main/java/to/dev/dev_android/view/main/view/MainActivity.kt
@@ -23,8 +23,13 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), CustomWebChromeClient.
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setWebViewSettings()
-        navigateToHome()
+        savedInstanceState?.let { restoreState(it) }?: navigateToHome()
         handleIntent(intent)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle?) {
+        binding.webView.saveState(outState)
+        super.onSaveInstanceState(outState)
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -45,6 +50,10 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), CustomWebChromeClient.
         binding.webView.settings.domStorageEnabled = true
         binding.webView.webViewClient = CustomWebViewClient(this@MainActivity, binding)
         binding.webView.webChromeClient = CustomWebChromeClient(this@MainActivity, binding, this)
+    }
+
+    private fun restoreState(savedInstanceState: Bundle){
+        binding.webView.restoreState(savedInstanceState)
     }
 
     private fun navigateToHome() {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
This PR has work that enables the webview to [save](https://developer.android.com/reference/android/webkit/WebView.html#saveState(android.os.Bundle)) it's state when the app is sent to the background and [restores](https://developer.android.com/reference/android/webkit/WebView.html#restoreState(android.os.Bundle)) it when brought back to the foreground. Should there be no state, the app will load the base url as defaulted.

## Related Tickets & Documents
This PR resolves #48 
## Screenshots/Recordings (if there are UI changes)

## [optional] What gif best describes this PR or how it makes you feel?
![The great gatsby dude raising a glass](https://media.giphy.com/media/rY93u9tQbybks/giphy.gif)

