### PR TITLE
The 'clean' task is already present

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,11 +33,6 @@ tasks.wrapper {
     distributionType = Wrapper.DistributionType.ALL
 }
 
-task("clean") {
-    group = "custom"
-    description = "Delete directory build"
-    delete(rootProject.buildDir)
-}
 tasks.register("hello") {
     group = "custom"
     description = "Hello World task - useful to solve build problems"


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description

The new added custom task ':clean'  is redundant as the project itself has a configuration already set for cleaning the project.

The new task only adds the posibility of being called with './gradlew :clean' instead of './gradlew clean' issue with this custom task is that it only clears the 'rootProject.buildDir' but currently the project has four build directories:

* app/build
* buildSrc/build
* data/build
* baseui/build

These directories should be cleaned on every call of the clean task and adding a new task for it seems redundant.

Other possible option is to add the cleanup by hand:

```
task("clean") {
     …
     delete(allprojects.map { it.buildDir }.toTypedArray())
}
```

But gradle does something similar to this. No actual need to process anything…

## Related Tickets & Documents

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/5qF688fc8X2XCQ4R2L/200w_d.gif)
