### PR TITLE
Add method to open native share sheet from within web-view.

### DIFF
--- a/app/src/main/java/to/dev/dev_android/util/AndroidWebViewBridge.kt
+++ b/app/src/main/java/to/dev/dev_android/util/AndroidWebViewBridge.kt
@@ -145,4 +145,21 @@ class AndroidWebViewBridge(private val context: Context) {
         val message = mapOf("action" to event.action, "currentTime" to event.seconds)
         webViewClient?.sendBridgeMessage("video", message)
     }
+
+    /**
+     * This method is used to open the native share-sheet of Android when simple text is to be
+     * shared from the web-view.
+     */
+    @JavascriptInterface
+    fun shareText(text: String) {
+        val shareIntent = Intent.createChooser(
+            Intent().apply {
+                action = Intent.ACTION_SEND
+                putExtra(Intent.EXTRA_TEXT, text)
+                type = "text/plain"
+            },
+            null
+        )
+        context.startActivity(shareIntent)
+    }
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
This PR adds the native method required to show the Android share sheet when sharing text from the website inside the web-view.

To complete the integration, some code needs to be added to the [https://dev.to](https://dev.to) also. Will create an issue for that over on [`thepracticaldev/dev.to`](https://github.com/thepracticaldev/dev.to) with specific instructions as to what changes need to be made.

## Related Tickets & Documents
Integrating this and its sibling changes in [thepracticaldev/dev.to](https://github.com/thepracticaldev/dev.to) (issue not created yet) will fix #11 