### PR TITLE
Remove the attribute which fixes the app to portrait mode.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,37 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools"
-          package="to.dev.dev_android">
+        xmlns:tools="http://schemas.android.com/tools"
+        package="to.dev.dev_android">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
             android:allowBackup="true"
             android:fullBackupContent="true"
-            android:usesCleartextTraffic="true"
             android:icon="@mipmap/ic_launcher"
             android:label="@string/app_name"
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="true"
             android:theme="@style/AppTheme"
-            tools:ignore="GoogleAppIndexingWarning,UnusedAttribute"
-    >
-        <activity
-                android:name=".view.main.view.MainActivity"
-                android:screenOrientation="portrait">
+            android:usesCleartextTraffic="true"
+            tools:ignore="GoogleAppIndexingWarning,UnusedAttribute">
+        <activity android:name=".view.main.view.MainActivity">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
+                <action android:name="android.intent.action.MAIN" />
 
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
             <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
                 <data
-                        android:scheme="https"
                         android:host="dev.to"
-                />
+                        android:scheme="https" />
             </intent-filter>
         </activity>
     </application>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

The app works only in portrait mode before this. There was a flag which was set so that the app never switched to landscape mode even when user rotates the phone.

Probably because originally we were not saving webview's state and then restoring it. This might have caused the webview to reload the app from scratch and not preserve where user was in the app.

Since the state saving and restoring was added some time ago. This now works smoothly(ish) even after we remove that flag which sets it to portrait-only.

One problem that happens is that user is initially greeted with the splash-screen on rotating the device until the webpage loads.

## Related Tickets & Documents

#62 

## Screenshots/Recordings (if there are UI changes)

## [optional] What gif best describes this PR or how it makes you feel?

![Dog happily typing on laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif)
