### PR TITLE
Includes error url to override for twitter authentication

### DIFF
--- a/app/src/main/java/to/dev/dev_android/view/main/view/CustomWebViewClient.kt
+++ b/app/src/main/java/to/dev/dev_android/view/main/view/CustomWebViewClient.kt
@@ -29,6 +29,7 @@ class CustomWebViewClient(
     private val overrideUrlList = listOf(
         "://dev.to",
         "api.twitter.com/oauth",
+        "api.twitter.com/login/error",
         "api.twitter.com/account/login_verification",
         "github.com/login",
         "github.com/sessions/"


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

When authenticating with Twitter is important include the urls in the override list for `CustomWebViewClient`. When someone fails to authenticate with Twitter the error url that Twitter uses is not included in this list, this causes the modal `CustomWebChromeClient` to open modally and this breaks the "encapsulation".

## Related Tickets & Documents

Resolves #82 

## Screenshots/Recordings (if there are UI changes)

**Before (modally presented with `CustomWebChromeClient`)**
![before_pic](https://user-images.githubusercontent.com/6045239/83188276-accc0800-a0ec-11ea-8cc0-b82eac5683ba.jpg)

**After (presented within `CustomWebViewClient`)**
![after_pic](https://user-images.githubusercontent.com/6045239/83188263-a9388100-a0ec-11ea-8756-df8971dd8ebb.jpg)


## [optional] What gif best describes this PR or how it makes you feel?

![ooops](https://media.giphy.com/media/26uf2pAocjgYpDQsg/giphy.gif)
