### PR TITLE
Support for video messaging back into the DOM & other enhancements

### DIFF
--- a/app/src/main/java/to/dev/dev_android/activities/BaseActivity.kt
+++ b/app/src/main/java/to/dev/dev_android/activities/BaseActivity.kt
@@ -15,8 +15,6 @@ abstract class BaseActivity<B: ViewDataBinding> : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-//        Log.i("LOLZ", this.javaClass.toString())
-//        Log.i("LOLZ", layout().toString())
         binding = DataBindingUtil.setContentView(this, layout())
     }
 

--- a/app/src/main/java/to/dev/dev_android/activities/VideoPlayerActivity.kt
+++ b/app/src/main/java/to/dev/dev_android/activities/VideoPlayerActivity.kt
@@ -9,13 +9,19 @@ import com.google.android.exoplayer2.SimpleExoPlayer
 import com.google.android.exoplayer2.source.hls.HlsMediaSource
 import com.google.android.exoplayer2.upstream.DataSource
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory
+import org.greenrobot.eventbus.EventBus
 import to.dev.dev_android.BuildConfig
 import to.dev.dev_android.R
 import to.dev.dev_android.databinding.ActivityVideoPlayerBinding
+import to.dev.dev_android.events.VideoPlayerPauseEvent
+import to.dev.dev_android.events.VideoPlayerTickEvent
+import to.dev.dev_android.webclients.CustomWebViewClient
+import java.util.*
 
 class VideoPlayerActivity : BaseActivity<ActivityVideoPlayerBinding>() {
 
     private var player: SimpleExoPlayer? = null
+    private val timer = Timer()
 
     override fun layout(): Int {
         return R.layout.activity_video_player
@@ -36,11 +42,26 @@ class VideoPlayerActivity : BaseActivity<ActivityVideoPlayerBinding>() {
         player?.prepare(mediaSource)
         player?.seekTo(videoTime.toLong() * 1000)
         player?.playWhenReady = true
+
+        val timeUpdateTask = object: TimerTask() {
+            override fun run() {
+                timeUpdate()
+            }
+        }
+        timer.schedule(timeUpdateTask, 0, 1000)
     }
 
     override fun onDestroy() {
         player?.playWhenReady = false
+        timer.cancel()
+        EventBus.getDefault().post(VideoPlayerPauseEvent())
         super.onDestroy()
+    }
+
+    fun timeUpdate() {
+        val milliseconds = (player?.currentPosition ?: 0)
+        val currentTime = (milliseconds / 1000).toString()
+        EventBus.getDefault().post(VideoPlayerTickEvent(currentTime))
     }
 
     companion object {

--- a/app/src/main/java/to/dev/dev_android/events/VideoPlayerPauseEvent.kt
+++ b/app/src/main/java/to/dev/dev_android/events/VideoPlayerPauseEvent.kt
@@ -1,0 +1,5 @@
+package to.dev.dev_android.events
+
+class VideoPlayerPauseEvent {
+    val action = "pause"
+}

--- a/app/src/main/java/to/dev/dev_android/events/VideoPlayerTickEvent.kt
+++ b/app/src/main/java/to/dev/dev_android/events/VideoPlayerTickEvent.kt
@@ -1,0 +1,5 @@
+package to.dev.dev_android.events
+
+class VideoPlayerTickEvent(val seconds: String) {
+    val action = "tick"
+}

--- a/app/src/main/java/to/dev/dev_android/webclients/CustomWebViewClient.kt
+++ b/app/src/main/java/to/dev/dev_android/webclients/CustomWebViewClient.kt
@@ -84,9 +84,14 @@ class CustomWebViewClient(
         return true
     }
 
-    fun sendPodcastMessage(message: Map<String, Any>) {
+    fun sendBridgeMessage(type: String, message: Map<String, Any>) {
         val jsonMessage = JSONObject(message).toString()
-        val javascript = "document.getElementById('audiocontent').setAttribute('data-podcast', '$jsonMessage')"
+        var javascript = ""
+        when(type) {
+            "podcast" -> javascript = "document.getElementById('audiocontent').setAttribute('data-podcast', '$jsonMessage')"
+            "video" -> javascript = "document.getElementById('video-player-source').setAttribute('data-message', '$jsonMessage')"
+            else -> return
+        }
         view?.post(Runnable {
             view?.evaluateJavascript(javascript, null)
         })


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Enhancement
- [ ] Bug Fix
- [ ] Documentation Update

## Description

The `tick` & `pause` messages sent back into the DOM are important because they help keep the UI on sync & when you pause and then play the video we will start off from where we stopped.

Also other minor cleanup/enhacements to better integrate with Podcasts logic

## Related Tickets & Documents

Builds on top of #90 

Works with the website implementation found on: [https://github.com/forem/forem/pull/9303](https://github.com/forem/forem/pull/9303)

## Screenshots/Recordings (if there are UI changes)

## [optional] What gif best describes this PR or how it makes you feel?

![much better](https://media.giphy.com/media/ALWsTtMzfjai4/giphy.gif)
