### PR TITLE
Bumped minSdkVersion to 21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ pusher.instanceId=cdaf9857-fad0-4bfb-b360-64c1b2693ef3
 # Android release configurations
 android.targetSdkVersion=29
 android.compileSdkVersion=29
-android.minSdkVersion=18
+android.minSdkVersion=21
 android.applicationId=to.dev.dev_android
 android.versionCode=12
 android.versionName=1.4.2


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

The minSdkVersion has been bumped to 21 from 18.

No further code changes appear to be necessary.

## Related Tickets & Documents

#88 - Bump the project minimum SDK API
