### PR TITLE
Fix bug on MainActivity onDestro. App crashes when closing the app with back button

### DIFF
--- a/app/src/main/java/to/dev/dev_android/util/AndroidWebViewBridge.kt
+++ b/app/src/main/java/to/dev/dev_android/util/AndroidWebViewBridge.kt
@@ -114,10 +114,12 @@ class AndroidWebViewBridge(private val context: Context) {
     fun terminatePodcast() {
         timer?.cancel()
         timer = null
-        audioService?.pause()
-        context.unbindService(connection)
-        audioService = null
-        context.stopService(Intent(context, AudioService::class.java))
+        audioService?.let {
+            it.pause()
+            context.unbindService(connection)
+            context.stopService(Intent(context, AudioService::class.java))
+            audioService = null
+        }
     }
 
     fun podcastTimeUpdate() {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

Before closing the app (for example when using the back button) the Main Activity (from `onDestroy()`) clears out lingering resources like the audio service. The webViewBridge wasn't checking to make sure the service exists before requesting the context to stop it causing the crash.

Killing the app directly from multitasking doesn't seem to execute the onDestroy() and this was a subtle problem that has been flying under the radar until now.

## Related Tickets & Documents

Fixes #106 

## [optional] What gif best describes this PR or how it makes you feel?

![doing nothing is everything](https://media.giphy.com/media/9JprEnb66Gn3QdPakE/giphy.gif)
